### PR TITLE
Fibers migration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "packages/non-core/blaze"]
-    path = packages/non-core/blaze
-    url = https://github.com/meteor/blaze.git

--- a/meteor
+++ b/meteor
@@ -31,9 +31,9 @@ if [ "$UNAME" = "Darwin" ] ; then
     fi
 elif [ "$UNAME" = "Linux" ] ; then
     : "${ARCH:=$(uname -m)}"
-    if [ "$ARCH" != "x86_64" ] ; then
+    if [ "$ARCH" != "x86_64" ] && [ "$ARCH" != "aarch64" ] ; then
         echo "Unsupported architecture: $ARCH"
-        echo "Meteor only supports x86_64"
+        echo "Meteor only supports x86_64 and aarch64"
         exit 1
     fi
 fi

--- a/meteor
+++ b/meteor
@@ -58,7 +58,7 @@ while true; do
 done
 cd "$ORIG_DIR"
 
-
+source "$SCRIPT_DIR/scripts/local-settings.sh"
 
 function install_dev_bundle {
     set -e
@@ -80,7 +80,14 @@ function install_dev_bundle {
         DEV_BUNDLE_URL_ROOT="https://s3.amazonaws.com/com.meteor.static/test/"
     fi
 
-    if [ -f "$SCRIPT_DIR/$TARBALL" ] ; then
+    if [ -n "$METEOR_DEV_BUNDLE_LOCAL_TARBALL" ] ; then
+        echo "Skipping download and installing kit from local $METEOR_DEV_BUNDLE_LOCAL_TARBALL" >&2
+        echo tar -xzf "$METEOR_DEV_BUNDLE_LOCAL_TARBALL" -C "$BUNDLE_TMPDIR"
+        tar -xzf "$METEOR_DEV_BUNDLE_LOCAL_TARBALL" -C "$BUNDLE_TMPDIR"
+        if [ -f "${METEOR_DEV_BUNDLE_LOCAL_TARBALL}.version" ]; then
+            cp "${METEOR_DEV_BUNDLE_LOCAL_TARBALL}.version" "$BUNDLE_TMPDIR/.bundle_version.txt"
+        fi
+    elif [ -f "$SCRIPT_DIR/$TARBALL" ] ; then
         echo "Skipping download and installing kit from $SCRIPT_DIR/$TARBALL" >&2
         tar -xzf "$SCRIPT_DIR/$TARBALL" -C "$BUNDLE_TMPDIR"
     elif [ -n "$SAVE_DEV_BUNDLE_TARBALL" ] ; then

--- a/packages/accounts-base/accounts_client.js
+++ b/packages/accounts-base/accounts_client.js
@@ -1,4 +1,5 @@
 import {AccountsCommon} from "./accounts_common.js";
+import {getBrowserId} from "./browser_id.js";
 
 /**
  * @summary Constructor for the `Accounts` object on the client.
@@ -182,6 +183,10 @@ export class AccountsClient extends AccountsCommon {
     );
   }
 
+  _getBrowserId() {
+    return getBrowserId();
+  }
+
   ///
   /// LOGIN METHODS
   ///
@@ -217,6 +222,9 @@ export class AccountsClient extends AccountsCommon {
       _suppressLoggingIn: false,
       ...options,
     };
+
+    if (options.methodName == 'login')
+      options.methodArguments[0].browserId = getBrowserId();
 
     // Set defaults for callback arguments to no-op functions; make sure we
     // override falsey values too.

--- a/packages/accounts-base/accounts_client.js
+++ b/packages/accounts-base/accounts_client.js
@@ -223,8 +223,9 @@ export class AccountsClient extends AccountsCommon {
       ...options,
     };
 
-    if (options.methodName == 'login')
-      options.methodArguments[0].browserId = getBrowserId();
+    options.methodArguments.push({
+      browserId: getBrowserId(),
+    });
 
     // Set defaults for callback arguments to no-op functions; make sure we
     // override falsey values too.

--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -642,10 +642,11 @@ export class AccountsServer extends AccountsCommon {
     //   If successful, returns {token: reconnectToken, id: userId}
     //   If unsuccessful (for example, if the user closed the oauth login popup),
     //     throws an error describing the reason
-    methods.login = async function (options) {
+    methods.login = async function (options, extraOptions) {
       // Login handlers should really also check whatever field they look at in
       // options, but we don't enforce it.
       check(options, Object);
+      check(extraOptions, Match.Maybe(Object));
 
       const result = await accounts._runLoginHandlers(this, options);
       //console.log({result});

--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -190,7 +190,7 @@ export class AccountsServer extends AccountsCommon {
       throw new Error("Can only call onCreateUser once");
     }
 
-    this._onCreateUserHook = func;
+    this._onCreateUserHook = Meteor.wrapFn(func);
   }
 
   /**
@@ -564,7 +564,7 @@ export class AccountsServer extends AccountsCommon {
 
     this._loginHandlers.push({
       name: name,
-      handler: handler
+      handler: Meteor.wrapFn(handler)
     });
   };
 

--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -745,9 +745,7 @@ export class AccountsServer extends AccountsCommon {
 
   _initAccountDataHooks() {
     this._server.onConnection(connection => {
-      this._accountData[connection.id] = {
-        connection: connection
-      };
+      this._setAccountData(connection.id, 'connection', connection);
 
       connection.onClose(() => {
         this._removeTokenFromConnection(connection.id);
@@ -861,12 +859,10 @@ export class AccountsServer extends AccountsCommon {
   };
 
   _setAccountData(connectionId, field, value) {
-    const data = this._accountData[connectionId];
+    let data = this._accountData[connectionId];
 
-    // safety belt. shouldn't happen. accountData is set in onConnection,
-    // we don't have a connectionId until it is set.
     if (!data)
-      return;
+      data = this._accountData[connectionId] = {};
 
     if (value === undefined)
       delete data[field];

--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -771,6 +771,9 @@ export class AccountsServer extends AccountsCommon {
     // Use Meteor.startup to give other packages a chance to call
     // setDefaultPublishFields.
     Meteor.startup(() => {
+      if (this._server.disable_default_user_publication)
+        return;
+
       // Merge custom fields selector and default publish fields so that the client
       // gets all the necessary fields to run properly
       const customFields = this._addDefaultFieldSelector().fields || {};

--- a/packages/accounts-base/browser_id.js
+++ b/packages/accounts-base/browser_id.js
@@ -1,0 +1,32 @@
+function getCookie(name) {
+  let regExp = new RegExp(`\\b${name}=([^;]+)`);
+  let match = document.cookie.match(regExp);
+  return match && match[1];
+}
+
+function setCookie(key, value) {
+  let cookie = key + "=" + value;
+  cookie += "; max-age=63072000";
+  cookie += "; path=/";
+
+  let url = Meteor.absoluteUrl();
+  if (/^https:/.test(url))
+    cookie += "; secure";
+
+  let hostname = url.match(/:\/\/([^\/:]*)/)[1];
+  if (hostname != "localhost")
+    cookie += "; domain=." + hostname;
+
+  document.cookie = cookie;
+}
+
+export function getBrowserId() {
+  let browserId = getCookie("xBrowserId");
+
+  if (!browserId) {
+    browserId = Random.id();
+    setCookie("xBrowserId", browserId);
+  }
+
+  return browserId;
+}

--- a/packages/accounts-base/browser_id.js
+++ b/packages/accounts-base/browser_id.js
@@ -8,6 +8,7 @@ function setCookie(key, value) {
   let cookie = key + "=" + value;
   cookie += "; max-age=63072000";
   cookie += "; path=/";
+  cookie += "; samesite=lax";
 
   let url = Meteor.absoluteUrl();
   if (/^https:/.test(url))

--- a/packages/accounts-base/server_main.js
+++ b/packages/accounts-base/server_main.js
@@ -1,5 +1,10 @@
 import { AccountsServer } from "./accounts_server.js";
 
+if (process.env.LOCAL_STORAGE_NAMESPACE !== undefined) {
+  __meteor_runtime_config__.LOCAL_STORAGE_NAMESPACE =
+    process.env.LOCAL_STORAGE_NAMESPACE;
+}
+
 /**
  * @namespace Accounts
  * @summary The namespace for all server-side accounts-related methods.

--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -171,11 +171,11 @@ Accounts.registerLoginHandler("password", async options => {
   if (!options.password)
     return undefined; // don't handle
 
-  check(options, {
+  check(options, Match.ObjectIncluding({
     user: Accounts._userQueryValidator,
     password: passwordValidator,
     code: Match.Optional(NonEmptyString),
-  });
+  }));
 
 
   const user = Accounts._findUserByQuery(options.user, {fields: {

--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -580,6 +580,7 @@ Accounts.sendEnrollmentEmail = (userId, email, extraTokenData, extraParams) => {
 Meteor.methods({resetPassword: async function (...args) {
   const token = args[0];
   const newPassword = args[1];
+  const extraOptions = args[2];
   return await Accounts._loginMethod(
     this,
     "resetPassword",
@@ -588,6 +589,7 @@ Meteor.methods({resetPassword: async function (...args) {
     async () => {
       check(token, String);
       check(newPassword, passwordValidator);
+      check(extraOptions, Match.Maybe(Object));
 
       let user = Meteor.users.findOne(
         {"services.password.reset.token": token},
@@ -742,6 +744,7 @@ Accounts.sendVerificationEmail = (userId, email, extraTokenData, extraParams) =>
 // and log them in.
 Meteor.methods({verifyEmail: async function (...args) {
   const token = args[0];
+  const extraOptions = args[1];
   return await Accounts._loginMethod(
     this,
     "verifyEmail",
@@ -749,6 +752,7 @@ Meteor.methods({verifyEmail: async function (...args) {
     "password",
     () => {
       check(token, String);
+      check(extraOptions, Match.Maybe(Object));
 
       const user = Meteor.users.findOne(
         {'services.email.verificationTokens.token': token},
@@ -952,6 +956,7 @@ const createUser = async options => {
 // method for create user. Requests come from the client.
 Meteor.methods({createUser: async function (...args) {
   const options = args[0];
+  const extraOptions = args[1];
   return await Accounts._loginMethod(
     this,
     "createUser",
@@ -960,6 +965,8 @@ Meteor.methods({createUser: async function (...args) {
     async () => {
       // createUser() above does more checking.
       check(options, Object);
+      check(extraOptions, Match.Maybe(Object));
+
       if (Accounts._options.forbidClientAccountCreation)
         return {
           error: new Meteor.Error(403, "Signups forbidden")

--- a/packages/callback-hook/hook.js
+++ b/packages/callback-hook/hook.js
@@ -49,6 +49,11 @@ export class Hook {
       this.bindEnvironment = false;
     }
 
+	this.wrapAsync = true;
+	if (options.wrapAsync === false) {
+		this.wrapAsync = false;
+	}
+
     if (options.exceptionHandler) {
       this.exceptionHandler = options.exceptionHandler;
     } else if (options.debugPrintExceptions) {
@@ -72,6 +77,10 @@ export class Hook {
     } else {
       callback = dontBindEnvironment(callback, exceptionHandler);
     }
+
+	if (this.wrapAsync) {
+		callback = Meteor.wrapFn(callback);
+	}
 
     const id = this.nextCallbackId++;
     this.callbacks[id] = callback;

--- a/packages/ddp-client/common/livedata_connection.js
+++ b/packages/ddp-client/common/livedata_connection.js
@@ -66,9 +66,9 @@ export class Connection {
       retry: true,
       respondToPings: true,
       // When updates are coming within this ms interval, batch them together.
-      bufferedWritesInterval: 5,
+      bufferedWritesInterval: 15,
       // Flush buffers immediately if writes are happening continuously for more than this many ms.
-      bufferedWritesMaxAge: 500,
+      bufferedWritesMaxAge: 30,
 
       ...options
     };

--- a/packages/ddp-client/common/livedata_connection.js
+++ b/packages/ddp-client/common/livedata_connection.js
@@ -1323,12 +1323,7 @@ export class Connection {
       // Begin a transactional update of each store.
 
       Object.entries(self._stores).forEach(([storeName, store]) => {
-        store.beginUpdate(
-          hasOwn.call(updates, storeName)
-            ? updates[storeName].length
-            : 0,
-          self._resetStores
-        );
+        store.beginUpdate(0, self._resetStores);
       });
 
       self._resetStores = false;

--- a/packages/ddp-server/livedata_server.js
+++ b/packages/ddp-server/livedata_server.js
@@ -1451,6 +1451,7 @@ Server = function (options = {}) {
 
   self.publish_handlers = {};
   self.universal_publish_handlers = [];
+  self.disable_default_user_publication = false;
 
   self.method_handlers = {};
 

--- a/packages/ddp-server/stream_server.js
+++ b/packages/ddp-server/stream_server.js
@@ -53,7 +53,8 @@ StreamServer = function () {
     // Set the USE_JSESSIONID environment variable to enable setting the
     // JSESSIONID cookie. This is useful for setting up proxies with
     // session affinity.
-    jsessionid: !!process.env.USE_JSESSIONID
+    jsessionid: !!process.env.USE_JSESSIONID,
+    disable_cors: !process.env.METEOR_ENABLE_CORS,
   };
 
   // If you know your server environment (eg, proxies) will prevent websockets

--- a/packages/deprecated/meteor-platform/package.js
+++ b/packages/deprecated/meteor-platform/package.js
@@ -44,7 +44,7 @@ Package.onUse(function(api) {
     // _.isUseful(true)
     'underscore',
     // $(".usefulToo")
-    'jquery',
+    'jquery@1.11.9 || 3.0.0',
     // Life isn't always predictable.
     'random',
     // People like being able to clone objects.

--- a/packages/meteor/dynamics_nodejs.js
+++ b/packages/meteor/dynamics_nodejs.js
@@ -75,7 +75,7 @@ EVp.withValue = function (value, func) {
   var saved = currentValues[this.slot];
   try {
     currentValues[this.slot] = value;
-    return func();
+    return Meteor.wrapFn(func)();
   } finally {
     currentValues[this.slot] = saved;
   }

--- a/packages/meteor/dynamics_nodejs.js
+++ b/packages/meteor/dynamics_nodejs.js
@@ -3,6 +3,7 @@
 var Fiber = Npm.require('fibers');
 
 var nextSlot = 0;
+var callAsyncMethodRunning = false;
 
 Meteor._nodeCodeMustBeInFiber = function () {
   if (!Fiber.current) {
@@ -105,6 +106,15 @@ EVp._setNewContextAndGetCurrent = function (value) {
   this._set(value);
   return saved;
 };
+
+EVp._isCallAsyncMethodRunning = function () {
+	return callAsyncMethodRunning;
+};
+
+EVp._setCallAsyncMethodRunning = function (value) {
+	callAsyncMethodRunning = value;
+};
+
 
 // Meteor application code is always supposed to be run inside a
 // fiber. bindEnvironment ensures that the function it wraps is run from

--- a/packages/meteor/helpers.js
+++ b/packages/meteor/helpers.js
@@ -156,6 +156,25 @@ Meteor.wrapAsync = function (fn, context) {
   };
 };
 
+Meteor.wrapFn = (fn) => {
+	if (!fn || typeof fn !== 'function') {
+		throw new Meteor.Error("Expected to receive function to wrap");
+	};
+
+	if (Meteor.isClient) {
+		return fn;
+	}
+
+	return function(...args) {
+		const ret = fn.apply(this, args);
+		if (ret && typeof ret.then === 'function') {
+			return Promise.await(ret);
+		}
+
+		return ret;
+	}
+};
+
 // Sets child's prototype to a new object whose prototype is parent's
 // prototype. Used as:
 //   Meteor._inherits(ClassB, ClassA).

--- a/packages/meteor/startup_client.js
+++ b/packages/meteor/startup_client.js
@@ -6,6 +6,9 @@ var isReady = false;
 // before we're considered ready.
 var readyHoldsCount = 0;
 
+if (window.meteorExtraReadyHolds === undefined)
+  window.meteorExtraReadyHolds = 0;
+
 var holdReady =  function () {
   readyHoldsCount++;
 }
@@ -16,7 +19,7 @@ var releaseReadyHold = function () {
 }
 
 var maybeReady = function () {
-  if (isReady || !isLoadingCompleted || readyHoldsCount > 0)
+  if (isReady || !isLoadingCompleted || readyHoldsCount > 0 || window.meteorExtraReadyHolds > 0)
     return;
 
   isReady = true;
@@ -62,6 +65,9 @@ if (document.readyState === 'complete' || document.readyState === 'loaded') {
   }
 }
 
+Meteor.holdReady = holdReady;
+Meteor.releaseReadyHold = releaseReadyHold;
+Meteor.maybeReady = maybeReady;
 /**
  * @summary Run code when a client or a server starts.
  * @locus Anywhere

--- a/packages/meteor/startup_server.js
+++ b/packages/meteor/startup_server.js
@@ -1,4 +1,5 @@
 Meteor.startup = function startup(callback) {
+  callback = Meteor.wrapFn(callback);
   if (process.env.METEOR_PROFILE) {
     // Create a temporary error to capture the current stack trace.
     var error = new Error("Meteor.startup");

--- a/packages/minimongo/cursor.js
+++ b/packages/minimongo/cursor.js
@@ -51,9 +51,18 @@ export default class Cursor {
    * @returns {Number}
    */
   count() {
-    if (this.reactive) {
+    if (this.reactive && Tracker.active) {
+      let numDocs = 0;
       // allow the observe to be unordered
-      this._depend({added: true, removed: true}, true);
+      this._depend({added: true, removed: true}, true, () => numDocs++);
+
+      if (this.skip)
+        numDocs = Math.max(0, numDocs - this.skip);
+
+      if (this.limit)
+        numDocs = Math.min(numDocs, this.limit);
+
+      return numDocs;
     }
 
     return this._getRawObjects({
@@ -80,26 +89,13 @@ export default class Cursor {
   }
 
   [Symbol.iterator]() {
-    if (this.reactive) {
-      this._depend({
-        addedBefore: true,
-        removed: true,
-        changed: true,
-        movedBefore: true});
-    }
-
     let index = 0;
-    const objects = this._getRawObjects({ordered: true});
+    const elements = this.fetch();
 
     return {
       next: () => {
-        if (index < objects.length) {
-          // This doubles as a clone operation.
-          let element = this._projectionFn(objects[index++]);
-
-          if (this._transform)
-            element = this._transform(element);
-
+        if (index < elements.length) {
+          let element = elements[index++];
           return {value: element};
         }
 
@@ -137,21 +133,30 @@ export default class Cursor {
    *                        `callback`.
    */
   forEach(callback, thisArg) {
-    if (this.reactive) {
+    if (this.reactive && Tracker.active) {
+      let i = 0;
+
       this._depend({
         addedBefore: true,
         removed: true,
         changed: true,
-        movedBefore: true});
+        movedBefore: true,
+      }, false, element => {
+        if (this._transform)
+          element = this._transform(element);
+
+        callback.call(thisArg, element, i++, this);
+      });
+
+      return;
     }
 
     this._getRawObjects({ordered: true}).forEach((element, i) => {
       // This doubles as a clone operation.
       element = this._projectionFn(element);
 
-      if (this._transform) {
+      if (this._transform)
         element = this._transform(element);
-      }
 
       callback.call(thisArg, element, i, this);
     });
@@ -314,15 +319,16 @@ export default class Cursor {
 
     if (!options._suppress_initial && !this.collection.paused) {
       query.results.forEach(doc => {
-        const fields = EJSON.clone(doc);
+        const fields = this._projectionFn(doc);
 
-        delete fields._id;
+        if (!options._keep_id)
+          delete fields._id;
 
-        if (ordered) {
-          query.addedBefore(doc._id, this._projectionFn(fields), null);
-        }
+        if (ordered && options.addedBefore)
+          options.addedBefore(doc._id, fields, null);
 
-        query.added(doc._id, this._projectionFn(fields));
+        if (options.added)
+          options.added(doc._id, fields);
       });
     }
 
@@ -346,34 +352,47 @@ export default class Cursor {
       });
     }
 
-    // run the observe callbacks resulting from the initial contents
-    // before we leave the observe.
-    this.collection._observeQueue.drain();
-
     return handle;
   }
 
   // XXX Maybe we need a version of observe that just calls a callback if
   // anything changed.
-  _depend(changers, _allow_unordered) {
-    if (Tracker.active) {
-      const dependency = new Tracker.Dependency;
-      const notify = dependency.changed.bind(dependency);
+  _depend(changers, _allow_unordered, initialDocCallback) {
+    const dependency = new Tracker.Dependency;
+    const notify = dependency.changed.bind(dependency);
 
-      dependency.depend();
+    dependency.depend();
 
-      const options = {_allow_unordered, _suppress_initial: true};
+    const options = {
+      _allow_unordered,
+      _keep_id: true,
+    };
 
-      ['added', 'addedBefore', 'changed', 'movedBefore', 'removed']
-        .forEach(fn => {
-          if (changers[fn]) {
-            options[fn] = notify;
-          }
-        });
+    ['added', 'addedBefore', 'changed', 'movedBefore', 'removed']
+      .forEach(fn => {
+        if (changers[fn]) {
+          options[fn] = notify;
+        }
+      });
 
-      // observeChanges will stop() when this computation is invalidated
-      this.observeChanges(options);
+    if (initialDocCallback) {
+      const notifyInitial = (id, doc) => {
+        if (initialDocCallback)
+          initialDocCallback(doc);
+        else
+          notify();
+      };
+
+      if (options.addedBefore)
+        options.addedBefore = notifyInitial;
+      else
+        options.added = notifyInitial;
     }
+
+    // observeChanges will stop() when this computation is invalidated
+    this.observeChanges(options);
+
+    initialDocCallback = undefined;
   }
 
   _getCollectionName() {

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -823,6 +823,19 @@ MongoConnection.prototype.findOne = function (collection_name, selector,
   return self.find(collection_name, selector, options).fetch()[0];
 };
 
+MongoConnection.prototype.findOneAsync = async function (collection_name, selector,
+											  options) {
+	var self = this;
+	if (arguments.length === 1)
+		selector = {};
+
+	options = options || {};
+	options.limit = 1;
+
+	const results = await self.find(collection_name, selector, options).fetchAsync();
+	return results[0];
+};
+
 // We'll actually design an index API later. For now, we just pass through to
 // Mongo's, but make it synchronous.
 MongoConnection.prototype.createIndex = function (collectionName, index,

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -1038,6 +1038,9 @@ MongoConnection.prototype._createSynchronousCursor = function(
   if (cursorOptions.session)
     mongoOptions.session = cursorOptions.session;
 
+  if (cursorOptions.comment)
+    mongoOptions.comment = cursorOptions.comment;
+
   var dbCursor = collection.find(
     replaceTypes(cursorDescription.selector, replaceMeteorAtomWithMongo),
     mongoOptions);

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -1098,7 +1098,7 @@ var SynchronousCursor = function (dbCursor, cursorDescription, options, collecti
     collection.countDocuments.bind(
       collection,
       replaceTypes(cursorDescription.selector, replaceMeteorAtomWithMongo),
-      replaceTypes(cursorDescription.options, replaceMeteorAtomWithMongo),
+      replaceTypes(_.omit(cursorDescription.options, 'session'), replaceMeteorAtomWithMongo),
     )
   );
   self._visitedIds = new LocalCollection._IdMap;

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -1193,6 +1193,7 @@ _.extend(SynchronousCursor.prototype, {
 
   forEach: function (callback, thisArg) {
     var self = this;
+	const wrappedFn = Meteor.wrapFn(callback);
 
     // Get back to the beginning.
     self._rewind();
@@ -1204,16 +1205,17 @@ _.extend(SynchronousCursor.prototype, {
     while (true) {
       var doc = self._nextObject();
       if (!doc) return;
-      callback.call(thisArg, doc, index++, self._selfForIteration);
+      wrappedFn.call(thisArg, doc, index++, self._selfForIteration);
     }
   },
 
   // XXX Allow overlapping callback executions if callback yields.
   map: function (callback, thisArg) {
     var self = this;
+	const wrappedFn = Meteor.wrapFn(callback);
     var res = [];
     self.forEach(function (doc, index) {
-      res.push(callback.call(thisArg, doc, index, self._selfForIteration));
+      res.push(wrappedFn.call(thisArg, doc, index, self._selfForIteration));
     });
     return res;
   },

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -172,6 +172,8 @@ MongoConnection = function (url, options) {
     // set it for replSet, it will be ignored if we're not using a replSet.
     mongoOptions.maxPoolSize = options.maxPoolSize;
   }
+  if (_.has(options, 'minPoolSize'))
+    mongoOptions.minPoolSize = options.minPoolSize;
 
   // Transform options like "tlsCAFileAsset": "filename.pem" into
   // "tlsCAFile": "/<fullpath>/filename.pem"

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -247,6 +247,10 @@ MongoConnection.prototype._createCappedCollection = function (
   if (! self.db)
     throw Error("_createCappedCollection called before Connection created?");
 
+  const collectionExists = self.db.listCollections({ name: collectionName }).hasNext().await();
+  if (collectionExists)
+    return;
+
   var future = new Future();
   self.db.createCollection(
     collectionName,

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -1028,6 +1028,12 @@ MongoConnection.prototype._createSynchronousCursor = function(
     mongoOptions.numberOfRetries = -1;
   }
 
+  if (cursorOptions.noCursorTimeout)
+    mongoOptions.noCursorTimeout = true;
+
+  if (cursorOptions.session)
+    mongoOptions.session = cursorOptions.session;
+
   var dbCursor = collection.find(
     replaceTypes(cursorDescription.selector, replaceMeteorAtomWithMongo),
     mongoOptions);

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -633,9 +633,10 @@ MongoConnection.prototype._update = function (collection_name, selector, mod,
 };
 
 var transformResult = function (driverResult) {
-  var meteorResult = { numberAffected: 0 };
+  var meteorResult = { numberAffected: 0, numberModified: 0 };
   if (driverResult) {
     var mongoResult = driverResult.result;
+    meteorResult.numberModified = mongoResult.nModified || mongoResult.modifiedCount;
     // On updates with upsert:true, the inserted values come as a list of
     // upserted values -- even with options.multi, when the upsert does insert,
     // it only inserts one element.
@@ -728,6 +729,7 @@ var simulateUpsertWithInsertedId = function (collection, selector, mod,
           } else if (result && (result.modifiedCount || result.upsertedCount)) {
             callback(null, {
               numberAffected: result.modifiedCount || result.upsertedCount,
+              numberModified: result.modifiedCount,
               insertedId: result.upsertedId || undefined,
             });
           } else {
@@ -756,6 +758,7 @@ var simulateUpsertWithInsertedId = function (collection, selector, mod,
         } else {
           callback(null, {
             numberAffected: result.upsertedCount,
+            numberModified: result.modifiedCount,
             insertedId: result.upsertedId,
           });
         }

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -597,8 +597,10 @@ MongoConnection.prototype._update = function (collection_name, selector, mod,
         Object.assign(mongoMod.$setOnInsert, replaceTypes({_id: options.insertedId}, replaceMeteorAtomWithMongo));
       }
 
-      const strings = Object.keys(mongoMod).filter((key) => !key.startsWith("$"));
-      let updateMethod = strings.length > 0 ? 'replaceOne' : 'updateMany';
+      const mongoModKeys = Object.keys(mongoMod);
+      const strings = mongoModKeys.filter((key) => !key.startsWith("$"));
+      let updateMethod = (strings.length > 0 || (options.upsert && mongoModKeys.length == 0)) ? 'replaceOne' : 'updateMany';
+
       updateMethod =
         updateMethod === 'updateMany' && !mongoOpts.multi
           ? 'updateOne'

--- a/packages/mongo/oplog_tailing.js
+++ b/packages/mongo/oplog_tailing.js
@@ -206,12 +206,12 @@ Object.assign(OplogHandle.prototype, {
     // The tail connection will only ever be running a single tail command, so
     // it only needs to make one underlying TCP connection.
     self._oplogTailConnection = new MongoConnection(
-      self._oplogUrl, {maxPoolSize: 1});
+      self._oplogUrl, {maxPoolSize: 1, minPoolSize: 1});
     // XXX better docs, but: it's to get monotonic results
     // XXX is it safe to say "if there's an in flight query, just use its
     //     results"? I don't think so but should consider that
     self._oplogLastEntryConnection = new MongoConnection(
-      self._oplogUrl, {maxPoolSize: 1});
+      self._oplogUrl, {maxPoolSize: 1, minPoolSize: 1});
 
     // Now, make sure that there actually is a repl set here. If not, oplog
     // tailing won't ever find anything!

--- a/packages/mongo/remote_collection_driver.js
+++ b/packages/mongo/remote_collection_driver.js
@@ -1,3 +1,8 @@
+import {
+  ASYNC_COLLECTION_METHODS,
+  getAsyncMethodName
+} from "meteor/minimongo/constants";
+
 MongoInternals.RemoteCollectionDriver = function (
   mongo_url, options) {
   var self = this;
@@ -28,7 +33,21 @@ Object.assign(MongoInternals.RemoteCollectionDriver.prototype, {
     REMOTE_COLLECTION_METHODS.forEach(
       function (m) {
         ret[m] = _.bind(self.mongo[m], self.mongo, name);
+
+        if (!ASYNC_COLLECTION_METHODS.includes(m)) return;
+        const asyncMethodName = getAsyncMethodName(m);
+        ret[asyncMethodName] = function (...args) {
+          let result;
+          try {
+            result = ret[m](...args);
+          } catch (error) {
+            return Promise.reject(error);
+          }
+
+          return Promise.resolve(result);
+        }
       });
+
     return ret;
   }
 });

--- a/packages/npm-mongo/.npm/package/npm-shrinkwrap.json
+++ b/packages/npm-mongo/.npm/package/npm-shrinkwrap.json
@@ -62,94 +62,94 @@
       }
     },
     "@aws-sdk/abort-controller": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.257.0.tgz",
-      "integrity": "sha512-ekWy391lOerS0ZECdhp/c+X7AToJIpfNrCPjuj3bKr+GMQYckGsYsdbm6AUD4sxBmfvuaQmVniSXWovaxwcFcQ=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.271.0.tgz",
+      "integrity": "sha512-sP4RvP0fvmMySS6hV/EKMrTJ9KVMH85rn1EKvmJ3nBTKRKiR8GQUS/vX+dhLYu+3jRs2P6cY2zjGzpaOcII91w=="
     },
     "@aws-sdk/client-cognito-identity": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.257.0.tgz",
-      "integrity": "sha512-/K5kLqZa8xrkk8ueLOdnHKZJxI0dp8J9X39y8B2zfJSqSb+n8ETqt0zo8kFcsn+JG746YyMby3t05YKCI5KLmg=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.271.0.tgz",
+      "integrity": "sha512-mPDRSMCnFjXccsi630+LqLycw5adry/eMPmzc76x6FLvXwW/tQtq1XsQT5MvwYKYasG78WhD/BBPymDENf6slQ=="
     },
     "@aws-sdk/client-sso": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.257.0.tgz",
-      "integrity": "sha512-sD0yTTctLbjDoSV3hJem+xz9BzusmkkU/4Fts9gEs4C5NjS0YrfPAvQWE++yRzPLPR/dMhDFVCOs7voTzUhUWQ=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.271.0.tgz",
+      "integrity": "sha512-auWPqok8yJ2UOQfNrvfLNmvf0tRAbekaZRvZZ2TzTKTKd7yz6V7Y5+AdRnp01FHoOQ+8A7MHTXtp7h7i9qltKw=="
     },
     "@aws-sdk/client-sso-oidc": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.257.0.tgz",
-      "integrity": "sha512-yXf53Zc7DYt/4j7xGXgWaDVhE/XMDLoid5l8bOb4aDJN6kxgl5bXV/sH3DwND/fA09EQHU1W+9oe/8InVqsliw=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.271.0.tgz",
+      "integrity": "sha512-pYN8r0slDbP0v2q0SyLKihE2PPfbsF/hH7+11w6OpAMvSGvfm+m8R5rB49Szy3bkDudR0MhLpD6D76yoy9ckrQ=="
     },
     "@aws-sdk/client-sts": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.257.0.tgz",
-      "integrity": "sha512-AVNngoDGACR7xs9wTU7hrZSvMfNOGvWP/B/ieA0au3H3KDucjCZzBd3j2vYkR6Cph9dY7YkpU2Gtzn+JXD0b1g=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.271.0.tgz",
+      "integrity": "sha512-dsLGj1Q3EdqLYNjm0WpeK07wv8Xed6R+tCf+x4KMWOAVAnz72XuoZNWDI2NvACubAniEhpFycMmf39Y6NCAkLg=="
     },
     "@aws-sdk/config-resolver": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.257.0.tgz",
-      "integrity": "sha512-jChjr8ayaXoAcUgrRr+JRIJ6bPtEoS+/xW9khpHOmrEX+uBJ7xLPfdS4e6nmxAQpbem9AsUVvf57DXhSh5/nLg=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.271.0.tgz",
+      "integrity": "sha512-WNtUjOa9ufKK4+o58YHosjU9J8v494Fb10tHFqD4OspFWLxBKzSJ+r6xpQRcVPucxsmocGJ2QhIiNYo8OySKkA=="
     },
     "@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.257.0.tgz",
-      "integrity": "sha512-KNXKB4llqDpUwxeOMIcOSL4BSklaClOctERDnmShN2h4gS9lgHN8dWQOuEqd0YkBVDtOg//tz0GeS5tsZsL5dA=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.271.0.tgz",
+      "integrity": "sha512-XL/CL31QVjaFqkCe3PSzesrip0DTI+idxiEyZ4s/DQ8NhxUVshE7wI00Wv+VQof1CtyT5ONWjhZrj00MD2L0tA=="
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.257.0.tgz",
-      "integrity": "sha512-GsmBi5Di6hk1JAi1iB6/LCY8o+GmlCvJoB7wuoVmXI3VxRVwptUVjuj8EtJbIrVGrF9dSuIRPCzUoSuzEzYGlg=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.271.0.tgz",
+      "integrity": "sha512-lKZGcDYe8us2Ep7/AjhLyMMTq0NuVt+M+L1eedBGRuGkx/Hrvn4qwlIvSXZhiodoQVa+Wr1zIah3Z06U0dTaZA=="
     },
     "@aws-sdk/credential-provider-imds": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.257.0.tgz",
-      "integrity": "sha512-UrxYkHWndy6s/bZZWH2poIyqdISTbILGTcK9tT8cFaUUrNIEFXiVESZMNNaagy0Dyy9wr80ndumxRkutYga9VA=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.271.0.tgz",
+      "integrity": "sha512-u3KsjtGBo1SA9HQAVxfA7zHWirlrdKsqsMpnp4eOtixZLoz1e2EytrR5XZem2HND0lzjrUrEPGDPp5OpDtcHxw=="
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.257.0.tgz",
-      "integrity": "sha512-69jW9/Os2zGBATQR8Urde+IlzicgJPCO/gAWpm4AYJYT5LSGc0pOuZflSXq+ZfKy3jcSoN0yOFxkoMnmZb8pzg=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.271.0.tgz",
+      "integrity": "sha512-zIclMwXbJeNev74+0tbxLpEO2Js7AhqvR2Msiytz05kOXRyk61NMEavtKRp1YxD2KMptONnvNlbWbNW2rrRDnw=="
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.257.0.tgz",
-      "integrity": "sha512-yXVNOml/w4ipWiRgLWUphGwISqJQRPjALgTsRa0O+CzpaEc/0HRqM8I78VzCzjsb+QE4EP7MZej6tkEAZYgTlg=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.271.0.tgz",
+      "integrity": "sha512-hfdJ+8QM5xXEm4mF4AfIy6T1fVb2zTaUVm5PfPDHtkggVM1L+QSywEkZ2lUqQZMLbbatJqVLy2EMA91k5kjVrA=="
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.257.0.tgz",
-      "integrity": "sha512-xK8uYeNXaclaBCGrLi4z2pxPRngqLf5BM5jg2fn57zqvlL9V5gJF972FehrVBL0bfp1/laG0ZJtD2K2sapyWAw=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.271.0.tgz",
+      "integrity": "sha512-Q1HIZYTUYLVe0cNc3HbtFOFzgo3A6PHcmT62T8XClAhFRhkOsJ/KWUybjm8col49/1uqIjKA20E7P7f5Qnn2TQ=="
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.257.0.tgz",
-      "integrity": "sha512-I/1TQm6WruqxTTPH+Wo2o+YCLenEY0bWq97EQn+d8Cp0N7cNJUDt8BHF22dQtUzd7bvSspVK5M4qCZKAh3fhOg=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.271.0.tgz",
+      "integrity": "sha512-TIvsv4xXTME6UsH7g05IzVDCLujaMmgv45A0KcAyM/J/HvFQ9IBOBdyKGU5zIawPvCWXiqQqZs/kDchdB2sjXA=="
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.257.0.tgz",
-      "integrity": "sha512-Cm0uvRv4JuIbD0Kp3W0J/vwjADIyCx8HoZi5yg+QIi5nilocuTQ3ajvLeuPVSvFvdy+yaxSc5FxNXquWt7Mngw=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.271.0.tgz",
+      "integrity": "sha512-GD1mg7fMA3ESl0jdzH/+keZHV9Fue/iaGMIWNCUm7M9dOJo0JZbDNzSaMtxZnuA6xtkvw3FiLH6ZxPt0V+7wmg=="
     },
     "@aws-sdk/credential-providers": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.257.0.tgz",
-      "integrity": "sha512-A2bl5M7BlcV94H4rgdYnWRcnQxVARkrWSNQzA1n/wJY3EPXkFN0/Rjie/W7j7hXVtjRVaALSGVNwxQ/BQ7ZMTg=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.271.0.tgz",
+      "integrity": "sha512-s3qTsTTZESfb2mvfxAgWUhOumdZHBXA+WzEqagvzwaxdRZSwrubtGYB24bm4e+TL6Rr7N5DTs6Ty3NPI524Jhw=="
     },
     "@aws-sdk/fetch-http-handler": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.257.0.tgz",
-      "integrity": "sha512-zOF+RzQ+wfF7tq7tGUdPcqUTh3+k2f8KCVJE07A8kCopVq4nBu4NH6Eq29Tjpwdya3YlKvE+kFssuQRRRRex+Q=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.271.0.tgz",
+      "integrity": "sha512-yc0YgKioACFcfs7RPtVHRlpsyYJNdEHkqiWtnRSXG0vuZHAkfvwzchrDK4bizMblnmEV/xbl495ZqDlVbQ0c9A=="
     },
     "@aws-sdk/hash-node": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.257.0.tgz",
-      "integrity": "sha512-W/USUuea5Ep3OJ2U7Ve8/5KN1YsDun2WzOFUxc1PyxXP5pW6OgC15/op0e+bmWPG851clvp5S8ZuroUr3aKi3Q=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.271.0.tgz",
+      "integrity": "sha512-VamRhkGo2uaVe7KhQhdTqpp9y5JKSFNE3yCUZf/o6lGwL9BgBpBiVqzwCePtas7hAphAaOYvefIwx0XLaCeQ1w=="
     },
     "@aws-sdk/invalid-dependency": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.257.0.tgz",
-      "integrity": "sha512-T68SAPRNMEhpke0wlxURgogL7q0B8dfqZsSeS20BVR/lksJxLse9+pbmCDxiu1RrXoEIsEwl5rbLN+Hw8BFFYw=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.271.0.tgz",
+      "integrity": "sha512-ZN8JmN/t+4UTHkQ6wdod2KKLfJcewLS3D/0iZLnvvOzLlymhcHp9QY8t//RObF+WxnlWeCAvZttoMl/a2MLpYQ=="
     },
     "@aws-sdk/is-array-buffer": {
       "version": "3.201.0",
@@ -157,124 +157,124 @@
       "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg=="
     },
     "@aws-sdk/middleware-content-length": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.257.0.tgz",
-      "integrity": "sha512-yiawbV2azm6QnMY1L2ypG8PDRdjOcEIvFmT0T7y0F49rfbKJOu21j1ONAoCkLrINK6kMqcD5JSQLVCoURxiTxQ=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.271.0.tgz",
+      "integrity": "sha512-bmfqCvjFcowa6jLltJIkGHNXY599Fu9ROoMtYjQiD2ixWHmUpS0I/VivcxXL3uES2qhehxYXyJFyCt7aqRQqcA=="
     },
     "@aws-sdk/middleware-endpoint": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.257.0.tgz",
-      "integrity": "sha512-RQNQe/jeVuWZtXXfcOm+e3qMFICY6ERsXUrbt0rjHgvajZCklcrRJgxJSCwrcS7Le3nl9azFPMAMj9L7uSK28g=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.271.0.tgz",
+      "integrity": "sha512-pibhIe57e68NAfDUY5c7d9zo6WfNwgfclwtrK0nV3OXw9psNeCLGLC1YbzsTun49tm0ICSmkHgmqfsXAVe4HWA=="
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.257.0.tgz",
-      "integrity": "sha512-gEi9AJdJfRfU8Qr6HK1hfhxTzyV3Giq4B/h7um99hIFAT/GCg9xiPvAOKPo6UeuiKEv3b7RpSL4s6cBvnJMJBA=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.271.0.tgz",
+      "integrity": "sha512-sp75WZDzDui/Wr3GnQH/db4DXgVdOpKdRQddDsRuULzri8HeJlhMW+JCP+sP0kQmkO06Dagxv1tSmENUxFhPaQ=="
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.257.0.tgz",
-      "integrity": "sha512-8RDXW/VbMKBsXDfcCLmROZcWKyrekyiPa3J1aIaBy0tq9o4xpGoXw/lwwIrNVvISAFslb57rteup34bfn6ta6w=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.271.0.tgz",
+      "integrity": "sha512-mB/vayfsuc20PySSpbbQ56CPER/RAZF5oGkwGuwFI3bY+VwRun0MOnx3yHj7Ja2DN1ZEOH1Hzrb0eUgREozmHw=="
     },
     "@aws-sdk/middleware-recursion-detection": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.257.0.tgz",
-      "integrity": "sha512-rUCih6zHh8k9Edf5N5Er4s508FYbwLM0MWTD2axzlj9TjLqEQ9OKED3wHaLffXSDzodd3oTAfJCLPbWQyoZ3ZQ=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.271.0.tgz",
+      "integrity": "sha512-prrS/YL3GdLODqVBSgxvpUfo9aPBLB3Km5wNBdbhjjN0rI1RqjD+0LquVgaz6C1VU/I8cYbnxrFYtQVcdgnWpg=="
     },
     "@aws-sdk/middleware-retry": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.257.0.tgz",
-      "integrity": "sha512-vDOy4PbSRW2gtgoJZ+yvgyxdlTwbZGpuv/rA2+XYxURmhPMzpmqs4o1DR37LG8O41WouI1rPzA7E+Ffo+iNWjw=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.271.0.tgz",
+      "integrity": "sha512-yCBXmxbFGT/4czTi+e4z7lV0nbMWctvvzOtl1ssBiG0LagijIhK4KUp0KTnqDJ+yBqxMpd7wNJ1B0NdS0re6Fw=="
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.257.0.tgz",
-      "integrity": "sha512-d6IJCLRi3O2tm4AFK60WNhIwmMmspj1WzKR1q1TaoPzoREPG2xg+Am18wZBRkCyYuRPPrbizmkvAmAJiUolMAw=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.271.0.tgz",
+      "integrity": "sha512-/h8+PAx+85M+tSL/kl1lWVgHrrodmDRuQuDLXC7ufE6C1JRxRBkWMTOg6S3ZeuKo1Va/8RcAKf7jtkGdIBD5HQ=="
     },
     "@aws-sdk/middleware-serde": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.257.0.tgz",
-      "integrity": "sha512-/JasfXPWFq24mnCrx9fxW/ISBSp07RJwhsF14qzm8Qy3Z0z470C+QRM6otTwAkYuuVt1wuLjja5agq3Jtzq7dQ=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.271.0.tgz",
+      "integrity": "sha512-louPEKEZP2TtTavMwg4k6IJjEbXC6xV05Wtb4I+ZKzjupoTG80nmLtgPU7rnvweej3D69aeSQETfPoq1N4u4mg=="
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.257.0.tgz",
-      "integrity": "sha512-hCH3D83LHmm6nqmtNrGTWZCVjsQXrGHIXbd17/qrw7aPFvcAhsiiCncGFP+XsUXEKa2ZqcSNMUyPrx69ofNRZQ=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.271.0.tgz",
+      "integrity": "sha512-jCxbt6sehnmV6we2uu0rY5McREJQ9WGQ3HCtjG1qSxm1vJkROX40IUvq7uvwPi3FquqIv2pCc64vLuDdhfs6OA=="
     },
     "@aws-sdk/middleware-stack": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.257.0.tgz",
-      "integrity": "sha512-awg2F0SvwACBaw4HIObK8pQGfSqAc4Vy+YFzWSfZNVC35oRO6RsRdKHVU99lRC0LrT2Ptmfghl2DMPSrRDbvlQ=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.271.0.tgz",
+      "integrity": "sha512-ojbvxVdJRzvHx1SiXTX8z5qtsX/86+puqqmhTNQTed0/sp856rJVHrE+59qrOa8tNX+dHih5nzmjZ2OvhP+duA=="
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.257.0.tgz",
-      "integrity": "sha512-37rt75LZyD0UWpbcFuxEGqwF3DZKSixQPl7AsDe6q3KtrO5gGQB+diH5vbY0txNNYyv5IK9WMwvY73mVmoWRmw=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.271.0.tgz",
+      "integrity": "sha512-VnoY5DfdkSorT/bM91FPwHduzkRFBTi/MyU/J08xPkuAQfu2CmvIBr8W15XN1ysAZbZVyDir7NeE9MNG6Q/soA=="
     },
     "@aws-sdk/node-config-provider": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.257.0.tgz",
-      "integrity": "sha512-IfGF7+cU0PyB7RpHlgc445ZAUZDWn4ij2HTB6N+xULwFw2TxnyQ2tvo3Gp5caW9VlJ3eXE9wFrynv+JXUIH7Bg=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.271.0.tgz",
+      "integrity": "sha512-PbEQ7GRO9/oXXrxIMPkOsL1lKzi3FzMizFj1tLjSkN+lvUaRt2w9Yrb+P3G7Wr2VyniI8QwpAPnebQ+5Rg7yig=="
     },
     "@aws-sdk/node-http-handler": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.257.0.tgz",
-      "integrity": "sha512-8KnWHVVwaGKyTlkTU9BSOAiSovNDoagxemU2l10QqBbzUCVpljCUMUkABEGRJ1yoQCl6DJ7RtNkAyZ8Ne/E15A=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.271.0.tgz",
+      "integrity": "sha512-r/wLPLUo3HeWHumvnYxP4LvMz1cKpVO7XVognt5caeDakS2CDiFN3NiCO2PFxOGoWCyMDKcroKtIdXETcgrEbQ=="
     },
     "@aws-sdk/property-provider": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.257.0.tgz",
-      "integrity": "sha512-3rUbRAcF0GZ5PhDiXhS4yREfZ5hOEtvYEa9S/19OdM5eoypOaLU5XnFcCKfnccSP8SkdgpJujzxOMRWNWadlAQ=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.271.0.tgz",
+      "integrity": "sha512-y95eWGs2tbCESZZVqNWbDXOL43y18bZSS0mfac2n7srOfeuVh+4+8Zdhsnz/NW3Ao61+k1IxKCFnX0iKfJSu2Q=="
     },
     "@aws-sdk/protocol-http": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.257.0.tgz",
-      "integrity": "sha512-xt7LGOgZIvbLS3418AYQLacOqx+mo5j4mPiIMz7f6AaUg+/fBUgESVsncKDqxbEJVwwCXSka8Ca0cntJmoeMSw=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.271.0.tgz",
+      "integrity": "sha512-WWyS/M+A0NoEBBLbgO1qG7oxEGWvhjsFJgX0Yzz38mKIjW8G/31X9ylaCQoGFSOTn6GXBRqc/i0P86os+wL45Q=="
     },
     "@aws-sdk/querystring-builder": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.257.0.tgz",
-      "integrity": "sha512-mZHWLP7XIkzx1GIXO5WfX/iJ+aY9TWs02RE9FkdL2+by0HEMR65L3brQTbU1mIBJ7BjaPwYH24dljUOSABX7yg=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.271.0.tgz",
+      "integrity": "sha512-2FKaoeOgCyn2eShq4hZrEBQ9euHYMvh0aFwWrjQgXjUWJmV4Q+/+eob/sEDeeYvkMW45T5aIG7D+hbVowgWZAQ=="
     },
     "@aws-sdk/querystring-parser": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.257.0.tgz",
-      "integrity": "sha512-UDrE1dEwWrWT8dG2VCrGYrPxCWOkZ1fPTPkjpkR4KZEdQDZBqU5gYZF2xPj8Nz7pjQVHFuW2wFm3XYEk56GEjg=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.271.0.tgz",
+      "integrity": "sha512-SGcxf+gaSMMST806zQxETEoe3ENWkncQh+cpDNDRo/oS582PMd7tIOAxP9JJdLJGp9UkIdSkTLWXDjzk9Zt02w=="
     },
     "@aws-sdk/service-error-classification": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.257.0.tgz",
-      "integrity": "sha512-FAyR0XsueGkkqDtkP03cTJQk52NdQ9sZelLynmmlGPUP75LApRPvFe1riKrou6+LsDbwVNVffj6mbDfIcOhaOw=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.271.0.tgz",
+      "integrity": "sha512-yTnxoeCa4uMRfpaaq6oG1h1a01vXQ2al+D0DyX+D5sw7u6RyZOaxxUEbyfEPTN+JtRw+M+zcdlvto3swIwRqoQ=="
     },
     "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.257.0.tgz",
-      "integrity": "sha512-HNjC1+Wx3xHiJc+CP14GhIdVhfQGSjroAsWseRxAhONocA9Fl1ZX4hx7+sA5c9nOoMVOovi6ivJ/6lCRPTDRrQ=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.271.0.tgz",
+      "integrity": "sha512-PR1Hco+r1sH7WlqxaO3Vvl6a8I5juvwVjwjjorbI3EVsxQgEcyCjy1ZVnpCAxY1Xam7ne5nAWO6Y6LtfY4JJ5g=="
     },
     "@aws-sdk/signature-v4": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.257.0.tgz",
-      "integrity": "sha512-aLQQN59X/D0+ShzPD3Anj5ntdMA/RFeNLOUCDyDvremViGi6yxUS98usQ/8bG5Rq0sW2GGMdbFUFmrDvqdiqEQ=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.271.0.tgz",
+      "integrity": "sha512-OzS+h0MGqzukJSrPqVi08pWDGZkq8U/yXf2LfCkQz58Rv/pbCuDIIN7Oab6IwnVPQV7KoCsegYL3e6BpOp1qpA=="
     },
     "@aws-sdk/smithy-client": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.257.0.tgz",
-      "integrity": "sha512-Vy/en+llpslHG6WZ2yuN+On6u7p2hROEURwAST/lpReAwBETjbsxylkWvP8maeGKQ54u9uC6lIZAOJut2I3INw=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.271.0.tgz",
+      "integrity": "sha512-8wqNArFoLx2hy2kT5jV7JsaZ4jIqI535K1WXBCkzVLKNMv6RVYCBN57I5+C5sgVtHCZwy9RLzRHJIGLEIKIfBg=="
     },
     "@aws-sdk/token-providers": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.257.0.tgz",
-      "integrity": "sha512-Ysd1dpWiI2oBOrJpkSJkgPsY0dwMtavIBzF3d5JYN1HCl14Aqc2jcNqBjD+7nEeL6CHXcFeyB7jmCDqiuP0V3A=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.271.0.tgz",
+      "integrity": "sha512-tCh3Pw7VuSGT6yg8n7IeNc25IT8cjPS9Q0YKzjN8rPBZW5iI8/kJyZ7kQBj52JD8WrEYCoxG4hnDvawe1e1lAA=="
     },
     "@aws-sdk/types": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.257.0.tgz",
-      "integrity": "sha512-LmqXuBQBGeaGi/3Rp7XiEX1B5IPO2UUfBVvu0wwGqVsmstT0SbOVDZGPmxygACbm64n+PRx3uTSDefRfoiWYZg=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.271.0.tgz",
+      "integrity": "sha512-w4oNKEaBul7eh2IM97c89xaH9Ti8+e+u/Rc1ZkgNtpnfOpDUU2t3ugJ91ihGH+xtASQCWJTopTDfX5CuKsQQtQ=="
     },
     "@aws-sdk/url-parser": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.257.0.tgz",
-      "integrity": "sha512-Qe/AcFe/NFZHa6cN2afXEQn9ehXxh57dWGdRjfjd2lQqNV4WW1R2pl2Tm1ZJ1dwuCNLJi4NHLMk8lrD3QQ8rdg=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.271.0.tgz",
+      "integrity": "sha512-HuL38pnLaZX4zjlsm9sZfyiPvEK9gFl9viX7wpBJcF50+KgRcj1rasYCy8AfWlCEtL7A214xEutFwGqLfTyDag=="
     },
     "@aws-sdk/util-base64": {
       "version": "3.208.0",
@@ -302,19 +302,19 @@
       "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg=="
     },
     "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.257.0.tgz",
-      "integrity": "sha512-nkfK+MNacVd3Px/fcAvU0hDeh+r7d+RLLt3sJ5Zc0gGd+i3OQEP58V8QzR9PYMvUvSvGQP16fQVQHSbRZtuWyQ=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.271.0.tgz",
+      "integrity": "sha512-zyCIT/4PKiBxblZLKcMTNCllKcPhLuE08lIv1fGaqgIZzULFaAGjd/lpTO1q7I2hOt5oFL/4uzTFDrG8g5HJAg=="
     },
     "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.257.0.tgz",
-      "integrity": "sha512-qsIb7aPbGFcKbBGoAQmlzv1gMcscgbpfrRh4rgNqkJXVbJ52Ql6+vXXfBmlWaBho0fcsNh5XnYu1fzdCuu+N7g=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.271.0.tgz",
+      "integrity": "sha512-QqruC9fkrraoWxrzG7EFX/pOkoLblV2YPsvPHR37DzKSssnsQxOPbiAF95Qw2zocsDrpDuxJEe2RM800vunIsw=="
     },
     "@aws-sdk/util-endpoints": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.257.0.tgz",
-      "integrity": "sha512-3bvmRn5XGYzPPWjLuvHBKdJOb+fijnb8Ungu9bfXnTYFsng/ndHUWeHC22O/p8w3OWoRYUIMaZHxdxe27BFozg=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.271.0.tgz",
+      "integrity": "sha512-qr+IWZB0Th+TcarjTW5ZakkbKxBNKlLsnFiw3j+gECDA5raUEyTB3w6tRH0nhPFNzN6cM5P8arKlpm3R7f002Q=="
     },
     "@aws-sdk/util-hex-encoding": {
       "version": "3.201.0",
@@ -327,14 +327,14 @@
       "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg=="
     },
     "@aws-sdk/util-middleware": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.257.0.tgz",
-      "integrity": "sha512-F9ieon8B8eGVs5tyZtAIG3DZEObDvujkspho0qRbUTHUosM0ylJLsMU800fmC/uRHLRrZvb/RSp59+kNDwSAMw=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.271.0.tgz",
+      "integrity": "sha512-qE+t+JKygIPtXvik1Dy9B2dQx8pJ5NFPms/uFi9kOexCJy8mWd4FApK+sCwT5TGWte+tY2Fg7fcTs5g7ufcsKw=="
     },
     "@aws-sdk/util-retry": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.257.0.tgz",
-      "integrity": "sha512-l9TOsOAYtZxwW3q5fQKW4rsD9t2HVaBfQ4zBamHkNTfB4vBVvCnz4oxkvSvA2MlxCA6am+K1K/oj917Tpqk53g=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.271.0.tgz",
+      "integrity": "sha512-tO3nHBtAlBSppM37AJNc/rUwLNypPvkDC7av2cyuCDTaH4OHLd/RqZUtvMtSXJKjxR4v8RiyiQvRVE65u0Ermw=="
     },
     "@aws-sdk/util-uri-escape": {
       "version": "3.201.0",
@@ -342,14 +342,14 @@
       "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA=="
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.257.0.tgz",
-      "integrity": "sha512-YdavWK6/8Cw6mypEgysGGX/dT9p9qnzFbnN5PQsUY+JJk2Nx8fKFydjGiQ+6rWPeW17RAv9mmbboh9uPVWxVlw=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.271.0.tgz",
+      "integrity": "sha512-nFU4flPzzkG6c46ZKroXtQc6D8g/8ei3nUYJF2Poc+3UD/GiuKASWR+ymALN7Zc2YfR95LcVCNdcm1rDI1WLXA=="
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.257.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.257.0.tgz",
-      "integrity": "sha512-fOHh80kiVomUkABmOv3ZxB/SNLnOPAja7uhQmGWfKHXBkcxTVfWO2KBs5vzU5qhVZA0c1zVEvZPcBdRsonnhlw=="
+      "version": "3.271.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.271.0.tgz",
+      "integrity": "sha512-okLJbQ1iBmAH+OdqDd6AmINUAQdLnhi+D9rvp4ZoE5DIhgbzFIuUK6SByB7Rl/9XE76wzkHfRhZJYPyD1cPkQA=="
     },
     "@aws-sdk/util-utf8": {
       "version": "3.254.0",
@@ -357,19 +357,14 @@
       "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw=="
     },
     "@aws-sdk/util-utf8-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
-      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q=="
-    },
-    "@aws-sdk/util-utf8-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
-      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ=="
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw=="
     },
     "@types/node": {
-      "version": "18.11.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
-      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
+      "version": "18.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
+      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg=="
     },
     "@types/webidl-conversions": {
       "version": "7.0.0",
@@ -422,9 +417,9 @@
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="
     },
     "mongodb": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.13.0.tgz",
-      "integrity": "sha512-+taZ/bV8d1pYuHL4U+gSwkhmDrwkWbH1l4aah4YpmpscMwgFBkufIKxgP/G7m87/NUuQzc2Z75ZTI7ZOyqZLbw=="
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.14.0.tgz",
+      "integrity": "sha512-coGKkWXIBczZPr284tYKFLg+KbGPPLlSbdgfKAb6QqCFt5bo5VFZ50O3FFzsw4rnkqjwT6D8Qcoo9nshYKM7Mg=="
     },
     "mongodb-connection-string-url": {
       "version": "2.6.0",
@@ -467,9 +462,9 @@
       "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA=="
     },
     "tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "uuid": {
       "version": "8.3.2",

--- a/packages/oauth/oauth_browser.js
+++ b/packages/oauth/oauth_browser.js
@@ -57,7 +57,7 @@ const openCenteredPopup = function(url, width, height) {
                   `,left=${left},top=${top},scrollbars=yes`);
 
 
-  const newwindow = window.open(url, 'Login', features);
+  const newwindow = window.open(url, undefined, features);
 
   if (!newwindow || newwindow.closed) {
     // blocked by a popup blocker maybe?

--- a/packages/oauth/oauth_client.js
+++ b/packages/oauth/oauth_client.js
@@ -38,11 +38,14 @@ OAuth._loginStyle = (service, config, options) => {
   return loginStyle;
 };
 
+OAuth.extraStateParams = {};
+
 OAuth._stateParam = (loginStyle, credentialToken, redirectUrl) => {
   const state = {
     loginStyle,
     credentialToken,
-    isCordova: Meteor.isCordova
+    isCordova: Meteor.isCordova,
+    ...OAuth.extraStateParams,
   };
 
   if (loginStyle === 'redirect' ||

--- a/packages/oauth/oauth_server.js
+++ b/packages/oauth/oauth_server.js
@@ -63,6 +63,9 @@ OAuth._generateState = (loginStyle, credentialToken, redirectUrl) => {
 };
 
 OAuth._stateFromQuery = query => {
+  if (!query.state)
+    return {};
+
   let string;
   try {
     string = Buffer.from(query.state, 'base64').toString('binary');
@@ -121,6 +124,10 @@ OAuth._isCordovaFromQuery = query => {
   }
 };
 
+OAuth.resultHandlerOverride = () => {
+  return false;
+};
+
 // Checks if the `redirectUrl` matches the app host.
 // We export this function so that developers can override this
 // behavior to allow apps from external domains to login using the
@@ -168,7 +175,7 @@ const middleware = async (req, res, next) => {
       requestData = req.body;
     }
 
-    await handler(service, requestData, res);
+    await handler(service, requestData, res, req);
   } catch (err) {
     // if we got thrown an error, save it off, it will get passed to
     // the appropriate login call (if any) and reported there.

--- a/packages/oauth/oauth_server.js
+++ b/packages/oauth/oauth_server.js
@@ -92,6 +92,10 @@ OAuth._loginStyleFromQuery = query => {
   } catch (err) {
     style = "popup";
   }
+
+  if (!style)
+    style = "popup";
+
   if (style !== "popup" && style !== "redirect") {
     throw new Error(`Unrecognized login style: ${style}`);
   }

--- a/packages/oauth1/oauth1_server.js
+++ b/packages/oauth1/oauth1_server.js
@@ -25,7 +25,10 @@ OAuth._queryParamsWithAuthTokenUrl = (authUrl, oauthBinding, params = {}, whitel
 };
 
 // connect middleware
-OAuth._requestHandlers['1'] = async (service, query, res) => {
+OAuth._requestHandlers['1'] = async (service, query, res, req) => {
+  if (OAuth.resultHandlerOverride(service, query, res, req))
+    return;
+    
   const config = ServiceConfiguration.configurations.findOne({service: service.serviceName});
   if (! config) {
     throw new ServiceConfiguration.ConfigError(service.serviceName);

--- a/packages/oauth2/oauth2_server.js
+++ b/packages/oauth2/oauth2_server.js
@@ -1,5 +1,8 @@
 // connect middleware
-OAuth._requestHandlers['2'] = async (service, query, res) => {
+OAuth._requestHandlers['2'] = async (service, query, res, req) => {
+  if (OAuth.resultHandlerOverride(service, query, res, req))
+    return;
+
   let credentialSecret;
 
   // check if user authorized access

--- a/packages/underscore/.npm/package/.gitignore
+++ b/packages/underscore/.npm/package/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/packages/underscore/.npm/package/README
+++ b/packages/underscore/.npm/package/README
@@ -1,0 +1,7 @@
+This directory and the files immediately inside it are automatically generated
+when you change this package's NPM dependencies. Commit the files in this
+directory (npm-shrinkwrap.json, .gitignore, and this README) to source control
+so that others run the same versions of sub-dependencies.
+
+You should NOT check in the node_modules directory that Meteor automatically
+creates; if you are using git, the .gitignore file tells git to ignore it.

--- a/packages/underscore/.npm/package/npm-shrinkwrap.json
+++ b/packages/underscore/.npm/package/npm-shrinkwrap.json
@@ -1,0 +1,10 @@
+{
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@types/underscore": {
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.11.4.tgz",
+      "integrity": "sha512-uO4CD2ELOjw8tasUrAhvnn2W4A0ZECOvMjCivJr4gA9pGgjv+qxKWY9GLTMVEK8ej85BxQOocUyE7hImmSQYcg=="
+    }
+  }
+}

--- a/scripts/admin/launch-meteor
+++ b/scripts/admin/launch-meteor
@@ -46,13 +46,20 @@ if [ ! -x "$METEOR_WAREHOUSE_DIR/meteor" ]; then
 
   if [ "$UNAME" = "Darwin" ] ; then
       ### OSX ###
-      if [ "i386" != "$(uname -p)" -o "1" != "$(sysctl -n hw.cpu64bit_capable 2>/dev/null || echo 0)" ] ; then
-          # Can't just test uname -m = x86_64, because Snow Leopard can
-          # return other values.
-          echo "Only 64-bit Intel processors are supported at this time."
-          exit 1
+      ARCH_LOCAL=$(uname -m)
+      if [ "$ARCH_LOCAL" == "x86_64" ]; then
+        PLATFORM="os.osx.x86_64"
+      elif if [ "$ARCH_LOCAL" == "arm64" ]; then
+        PLATFORM="os.osx.arm64"
+      else
+        if [ "i386" != "$(uname -p)" -o "1" != "$(sysctl -n hw.cpu64bit_capable 2>/dev/null || echo 0)" ] ; then
+            # Can't just test uname -m = x86_64, because Snow Leopard can
+            # return other values.
+            echo "Only 64-bit Intel or ARM processors are supported at this time."
+            exit 1
+        fi
+        PLATFORM="os.osx.x86_64"
       fi
-      PLATFORM="os.osx.x86_64"
   elif [ "$UNAME" = "Linux" ] ; then
       ### Linux ###
       LINUX_ARCH=$(uname -m)

--- a/scripts/admin/launch-meteor
+++ b/scripts/admin/launch-meteor
@@ -67,9 +67,11 @@ if [ ! -x "$METEOR_WAREHOUSE_DIR/meteor" ]; then
           PLATFORM="os.linux.x86_32"
       elif [ "${LINUX_ARCH}" = "x86_64" ] ; then
           PLATFORM="os.linux.x86_64"
+      elif [ "${LINUX_ARCH}" = "aarch64" ] ; then
+          PLATFORM="os.linux.aarch64"
       else
           echo "Unusable architecture: ${LINUX_ARCH}"
-          echo "Meteor only supports i686 and x86_64 for now."
+          echo "Meteor only supports i686, x86_64 and aarch64 for now."
           exit 1
       fi
   fi

--- a/scripts/build-dev-bundle-common.sh
+++ b/scripts/build-dev-bundle-common.sh
@@ -13,7 +13,7 @@ NPM_VERSION=6.14.17
 
 if [ "$UNAME" == "Linux" ] ; then
     NODE_BUILD_NUMBER=
-    if [ "$ARCH" != "i686" -a "$ARCH" != "x86_64" ] ; then
+    if [ "$ARCH" != "i686" -a "$ARCH" != "x86_64" -a "$ARCH" != "aarch64"  ] ; then
         echo "Unsupported architecture: $ARCH"
         echo "Meteor only supports i686 and x86_64 for now."
         exit 1
@@ -65,6 +65,9 @@ then
     elif [ "$ARCH" == "x86_64" ]
     then
         NODE_TGZ="node-v${NODE_VERSION}-linux-x64.tar.gz"
+    elif [ "$ARCH" == "aarch64" ]
+    then
+        NODE_TGZ="node-v${NODE_VERSION}-linux-aarch64.tar.gz"
     else
         echo "Unknown architecture: $UNAME $ARCH"
         exit 1

--- a/scripts/build-dev-bundle-common.sh
+++ b/scripts/build-dev-bundle-common.sh
@@ -86,7 +86,8 @@ cd "$SCRIPTS_DIR/.."
 CHECKOUT_DIR=$(pwd)
 
 DIR=$(mktemp -d -t generate-dev-bundle-XXXXXXXX)
-trap 'rm -rf "$DIR" >/dev/null 2>&1' 0
+METEOR_DEV_BUNDLE_TEMP_DIRECTORY="$DIR"
+trap 'rm -rf "$METEOR_DEV_BUNDLE_TEMP_DIRECTORY" >/dev/null 2>&1' 0
 
 cd "$DIR"
 chmod 755 .

--- a/scripts/dev-bundle-server-package.js
+++ b/scripts/dev-bundle-server-package.js
@@ -26,7 +26,8 @@ var packageJson = {
   devDependencies: {
     split2: "3.2.2",
     multipipe: "1.0.2",
-    chalk: "0.5.1"
+    chalk: "0.5.1",
+    "emoji-regex": "^10.0.0"
   }
 };
 

--- a/scripts/generate-dev-bundle.sh
+++ b/scripts/generate-dev-bundle.sh
@@ -163,6 +163,8 @@ node "${CHECKOUT_DIR}/scripts/dev-bundle-server-package.js" > package.json
 # error if we do not help it by creating the .npm/_locks directory.
 mkdir -p "${DIR}/.npm/_locks"
 npm install
+npm outdated
+npm audit || true
 npm shrinkwrap
 
 mkdir -p "${DIR}/server-lib/node_modules"
@@ -184,6 +186,8 @@ else
     node "${CHECKOUT_DIR}/scripts/dev-bundle-tool-package.js" >package.json
 fi
 npm install
+npm outdated
+npm audit || true
 cp -R node_modules/* "${DIR}/lib/node_modules/"
 # Also include node_modules/.bin, so that `meteor npm` can make use of
 # commands like node-gyp and node-pre-gyp.

--- a/scripts/generate-dev-bundle.sh
+++ b/scripts/generate-dev-bundle.sh
@@ -3,6 +3,8 @@
 set -e
 set -u
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 # Read the bundle version from the meteor shell script.
 BUNDLE_VERSION=$(perl -ne 'print $1 if /BUNDLE_VERSION=(\S+)/' meteor)
 if [ -z "$BUNDLE_VERSION" ]; then
@@ -10,11 +12,30 @@ if [ -z "$BUNDLE_VERSION" ]; then
     exit 1
 fi
 
-source "$(dirname $0)/build-dev-bundle-common.sh"
+source "$SCRIPT_DIR/build-dev-bundle-common.sh"
+source "$SCRIPT_DIR/local-settings.sh"
+
+if [[ "$METEOR_DEV_BUNDLE_EXTERNAL_VERSION" == "true" ]] ; then
+    BUNDLE_VERSION="UNKNOWN"
+fi
+
+if [[ "$METEOR_DEV_BUNDLE_OUTPUT_TAR" == "" ]] ; then
+    METEOR_DEV_BUNDLE_OUTPUT_TAR="${CHECKOUT_DIR}/dev_bundle_${PLATFORM}_${BUNDLE_VERSION}.tar.gz"
+fi
+
 echo CHECKOUT DIR IS "$CHECKOUT_DIR"
-echo BUILDING DEV BUNDLE "$BUNDLE_VERSION" IN "$DIR"
+echo BUILDING DEV BUNDLE "$BUNDLE_VERSION" IN "$DIR" to "$METEOR_DEV_BUNDLE_OUTPUT_TAR"
 
 cd "$DIR"
+
+extractNodeFromLocalTarGz() {
+    if [ -f "$METEOR_DEV_BUNDLE_LOCAL_NODE" ] ; then
+        echo "Skipping download and installing Node from local $METEOR_DEV_BUNDLE_LOCAL_NODE" >&2
+        tar --strip-components 1 -zxf "$METEOR_DEV_BUNDLE_LOCAL_NODE"
+        return 0
+    fi
+    return 1
+}
 
 extractNodeFromTarGz() {
     LOCAL_TGZ="${CHECKOUT_DIR}/node_${PLATFORM}_v${NODE_VERSION}.tar.gz"
@@ -49,52 +70,69 @@ downloadReleaseCandidateNode() {
 }
 
 # Try each strategy in the following order:
-extractNodeFromTarGz || downloadNodeFromS3 || \
+extractNodeFromLocalTarGz || extractNodeFromTarGz || downloadNodeFromS3 || \
   downloadOfficialNode || downloadReleaseCandidateNode
 
-# On macOS, download MongoDB from mongodb.com. On Linux, download a custom build
-# that is compatible with current distributions. If a 32-bit Linux is used,
-# download a 32-bit legacy version from mongodb.com instead.
-MONGO_VERSION=$MONGO_VERSION_64BIT
-
-if [ $ARCH = "i686" ] && [ $OS = "linux" ]; then
-    MONGO_VERSION=$MONGO_VERSION_32BIT
-fi
-
-case $OS in
-    macos) MONGO_BASE_URL="https://fastdl.mongodb.org/osx" ;;
-    linux)
-        [ $ARCH = "i686" ] &&
-            MONGO_BASE_URL="https://fastdl.mongodb.org/linux" ||
-            MONGO_BASE_URL="https://github.com/meteor/mongodb-builder/releases/download/v${MONGO_VERSION}"
-        ;;
-esac
-
-
-if [ $OS = "macos" ] && [ "$(uname -m)" = "arm64" ] ; then
-  MONGO_NAME="mongodb-${OS}-x86_64-${MONGO_VERSION}"
+if [[ "$METEOR_DEV_BUNDLE_LOCAL_MONGO" != "" ]] ; then
+    echo "Copying mongodb from local dir: $METEOR_DEV_BUNDLE_LOCAL_MONGO"
+    mkdir -p "mongodb/bin"
+    cp "${METEOR_DEV_BUNDLE_LOCAL_MONGO}/bin/mongod" "mongodb/bin"
+    if [ -f "${METEOR_DEV_BUNDLE_LOCAL_MONGO}/bin/mongo" ]; then
+        cp "${METEOR_DEV_BUNDLE_LOCAL_MONGO}/bin/mongo" "mongodb/bin"
+    fi
+    if [ -f "${METEOR_DEV_BUNDLE_LOCAL_MONGO}/bin/mongos" ]; then
+        cp "${METEOR_DEV_BUNDLE_LOCAL_MONGO}/bin/mongos" "mongodb/bin"
+    fi
 else
-  MONGO_NAME="mongodb-${OS}-${ARCH}-${MONGO_VERSION}"
+    # On macOS, download MongoDB from mongodb.com. On Linux, download a custom build
+    # that is compatible with current distributions. If a 32-bit Linux is used,
+    # download a 32-bit legacy version from mongodb.com instead.
+    MONGO_VERSION=$MONGO_VERSION_64BIT
+
+    if [ $ARCH = "i686" ] && [ $OS = "linux" ]; then
+        MONGO_VERSION=$MONGO_VERSION_32BIT
+    fi
+
+    case $OS in
+        macos) MONGO_BASE_URL="https://fastdl.mongodb.org/osx" ;;
+        linux)
+            [ $ARCH = "i686" ] &&
+                MONGO_BASE_URL="https://fastdl.mongodb.org/linux" ||
+                MONGO_BASE_URL="https://github.com/meteor/mongodb-builder/releases/download/v${MONGO_VERSION}"
+            ;;
+    esac
+
+
+    if [ $OS = "macos" ] && [ "$(uname -m)" = "arm64" ] ; then
+      MONGO_NAME="mongodb-${OS}-x86_64-${MONGO_VERSION}"
+    else
+      MONGO_NAME="mongodb-${OS}-${ARCH}-${MONGO_VERSION}"
+    fi
+
+    MONGO_TGZ="${MONGO_NAME}.tgz"
+    MONGO_URL="${MONGO_BASE_URL}/${MONGO_TGZ}"
+    echo "Downloading Mongo from ${MONGO_URL}"
+    curl -L "${MONGO_URL}" | tar zx
+
+    # Put Mongo binaries in the right spot (mongodb/bin)
+    mkdir -p "mongodb/bin"
+    mv "${MONGO_NAME}/bin/mongod" "mongodb/bin"
+    mv "${MONGO_NAME}/bin/mongos" "mongodb/bin"
+    rm -rf "${MONGO_NAME}"
 fi
-
-MONGO_TGZ="${MONGO_NAME}.tgz"
-MONGO_URL="${MONGO_BASE_URL}/${MONGO_TGZ}"
-echo "Downloading Mongo from ${MONGO_URL}"
-curl -L "${MONGO_URL}" | tar zx
-
-# Put Mongo binaries in the right spot (mongodb/bin)
-mkdir -p "mongodb/bin"
-mv "${MONGO_NAME}/bin/mongod" "mongodb/bin"
-mv "${MONGO_NAME}/bin/mongos" "mongodb/bin"
-rm -rf "${MONGO_NAME}"
 
 # export path so we use the downloaded node and npm
 export PATH="$DIR/bin:$PATH"
 
-cd "$DIR/lib"
-# Overwrite the bundled version with the latest version of npm.
-npm install "npm@$NPM_VERSION"
-npm config set python `which python3`
+if [[ "$METEOR_DEV_BUNDLE_OVERRIDE_NPM" != "false" ]] ; then
+    cd "$DIR/lib"
+    # Overwrite the bundled version with the latest version of npm.
+    npm install "npm@$NPM_VERSION"
+    npm config set python `which python3`
+else
+    echo "Skipping install of npm"
+fi
+
 which node
 which npm
 npm version
@@ -138,7 +176,13 @@ mv package.json npm-shrinkwrap.json "${DIR}/etc/"
 # tool.
 mkdir "${DIR}/build/npm-tool-install"
 cd "${DIR}/build/npm-tool-install"
-node "${CHECKOUT_DIR}/scripts/dev-bundle-tool-package.js" >package.json
+if [[ "$METEOR_DEV_BUNDLE_OVERRIDE_NPM" == "false" ]] ; then
+    sed -e 's/npm:/\/\/ npm:/g' "${CHECKOUT_DIR}/scripts/dev-bundle-tool-package.js" > "$DIR/dev-bundle-tool-package.js"
+    node "$DIR/dev-bundle-tool-package.js" >package.json
+    rm -f "$DIR/dev-bundle-tool-package.js"
+else
+    node "${CHECKOUT_DIR}/scripts/dev-bundle-tool-package.js" >package.json
+fi
 npm install
 cp -R node_modules/* "${DIR}/lib/node_modules/"
 # Also include node_modules/.bin, so that `meteor npm` can make use of
@@ -181,7 +225,7 @@ find . -path '*/esprima-fb/test' | xargs rm -rf
 # Sanity check to see if we're not breaking anything by replacing npm
 INSTALLED_NPM_VERSION=$(cat "$DIR/lib/node_modules/npm/package.json" |
 xargs -0 node -e "console.log(JSON.parse(process.argv[1]).version)")
-if [ "$INSTALLED_NPM_VERSION" != "$NPM_VERSION" ]; then
+if [ "$INSTALLED_NPM_VERSION" != "$NPM_VERSION" ] && [[ "$METEOR_DEV_BUNDLE_OVERRIDE_NPM" != "false" ]]; then
   echo "Error: Unexpected NPM version in lib/node_modules: $INSTALLED_NPM_VERSION"
   echo "Update this check if you know what you're doing."
   exit 1
@@ -190,9 +234,14 @@ fi
 echo BUNDLING
 
 cd "$DIR"
-echo "${BUNDLE_VERSION}" > .bundle_version.txt
+
+if [[ "$BUNDLE_VERSION" != "UNKNOWN" ]] ; then
+    echo "${BUNDLE_VERSION}" > .bundle_version.txt
+fi
+
 rm -rf build CHANGELOG.md ChangeLog LICENSE README.md .npm
 
-tar czf "${CHECKOUT_DIR}/dev_bundle_${PLATFORM}_${BUNDLE_VERSION}.tar.gz" .
+mkdir -p "$( dirname "$METEOR_DEV_BUNDLE_OUTPUT_TAR" )"
+tar czf "$METEOR_DEV_BUNDLE_OUTPUT_TAR" .
 
 echo DONE

--- a/scripts/local-settings.sh
+++ b/scripts/local-settings.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+SAVED_OPTIONS=$(set +o)
+
+set -e
+set -u
+
+LOCAL_SETTINGS_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
+LOCAL_SETTINGS_FILE="$LOCAL_SETTINGS_SCRIPT_DIR/meteor_local_settings.sh"
+
+if [ -x "$LOCAL_SETTINGS_FILE" ] ; then
+    source "$LOCAL_SETTINGS_FILE"
+else
+    METEOR_DEV_BUNDLE_EXTERNAL_VERSION=""
+    METEOR_DEV_BUNDLE_OUTPUT_TAR=""
+    METEOR_DEV_BUNDLE_LOCAL_TARBALL=""
+    METEOR_DEV_BUNDLE_LOCAL_MONGO=""
+    METEOR_DEV_BUNDLE_LOCAL_NODE=""
+    METEOR_DEV_BUNDLE_OVERRIDE_NPM="true"
+fi
+
+eval "$SAVED_OPTIONS"

--- a/tools/cli/commands-packages.js
+++ b/tools/cli/commands-packages.js
@@ -9,6 +9,7 @@ var httpHelpers = require('../utils/http-helpers.js');
 var compiler = require('../isobuild/compiler.js');
 var catalog = require('../packaging/catalog/catalog.js');
 var catalogRemote = require('../packaging/catalog/catalog-remote.js');
+var catalogLocal = require('../packaging/catalog/catalog-local.js');
 var isopack = require('../isobuild/isopack.js');
 var Console = require('../console/console.js').Console;
 var projectContextModule = require('../project-context.js');
@@ -21,6 +22,10 @@ var updater = require('../packaging/updater.js');
 var packageMapModule = require('../packaging/package-map.js');
 var packageClient = require('../packaging/package-client.js');
 var tropohouse = require('../packaging/tropohouse.js');
+
+import {
+  newIsopacketBuildingCatalog,
+} from '../tool-env/isopackets.js';
 
 import {
   ensureDevBundleDependencies,
@@ -1459,6 +1464,49 @@ var getNewerVersion = function (packageName, curVersion, whichCatalog) {
 ///////////////////////////////////////////////////////////////////////////////
 // update
 ///////////////////////////////////////////////////////////////////////////////
+var doUpdateRelease = function (options, projectContext, releaseName, releaseRecord) {
+  // We could at this point springboard to solutionRelease (which is no newer
+  // than the release we are currently running), but there's no super-clear
+  // advantage to this yet. The main reason might be if we decide to delete some
+  // backward-compatibility code which knows how to deal with an older release,
+  // but if we actually do that, we can change this code to add the extra
+  // springboard at that time.
+  var upgraders = require('../upgraders.js');
+  var upgradersToRun = upgraders.upgradersToRun(projectContext);
+
+  // Update every package in .meteor/packages to be (semver)>= the version
+  // set for that package in the release we are updating to
+  projectContext.projectConstraintsFile.updateReleaseConstraints(releaseRecord);
+
+  // Download and build packages and write the new versions to .meteor/versions.
+  // XXX It's a little weird that we do a full preparation for build
+  //     (downloading packages, building packages, etc) when we might be about
+  //     to upgrade packages and have to do it again. Maybe we shouldn't? Note
+  //     that if we change this, that changes the upgraders interface, which
+  //     expects a projectContext that is fully prepared for build.
+  main.captureAndExit("=> Errors while initializing project:", function () {
+    projectContext.prepareProjectForBuild();
+  });
+
+  if (releaseName)
+    projectContext.writeReleaseFileAndDevBundleLink(releaseName);
+
+  projectContext.packageMapDelta.displayOnConsole({
+    title: ("Changes to your project's package version selections from " +
+            "updating the release:")
+  });
+
+  Console.info(files.pathBasename(options.appDir) + ": updated to " +
+               projectContext.releaseFile.displayReleaseName + ".");
+
+  // Now run the upgraders.
+  // XXX should we also run upgraders on other random commands, in case there
+  // was a crash after changing .meteor/release but before running them?
+  _.each(upgradersToRun, function (upgrader) {
+    upgraders.runUpgrader(projectContext, upgrader);
+    projectContext.finishedUpgraders.appendUpgraders([upgrader]);
+  });
+}
 
 // Returns 0 if the operation went OK -- either we updated to a new release, or
 // decided not to with good reason. Returns something other than 0, if it is not
@@ -1472,9 +1520,23 @@ var maybeUpdateRelease = function (options) {
 
   // We are running from checkout, so we are not updating the release.
   if (release.current && release.current.isCheckout()) {
-    Console.error(
-      "You are running Meteor from a checkout, so we cannot update",
-      "the Meteor release. Checking to see if we can update your packages.");
+    if (!process.env.METEOR_CHECKOUT_IS_RELEASE) {
+      Console.error(
+        "You are running Meteor from a checkout, so we cannot update",
+        "the Meteor release. Checking to see if we can update your packages.");
+      return 0;
+    }
+
+    var projectContext = new projectContextModule.ProjectContext({
+      projectDir: options.appDir,
+      alwaysWritePackageMap: true,
+      allowIncompatibleUpdate: true // disregard `.meteor/versions` if necessary
+    });
+    main.captureAndExit("=> Errors while initializing project:", function () {
+      projectContext.readProjectMetadata();
+    });
+
+    doUpdateRelease(options, projectContext, null, newIsopacketBuildingCatalog().getReleaseRecord());
     return 0;
   }
 
@@ -1696,48 +1758,8 @@ var maybeUpdateRelease = function (options) {
   }
 
   var releaseName = `${releaseTrack}@${releaseVersion}`;
-
-  // We could at this point springboard to solutionRelease (which is no newer
-  // than the release we are currently running), but there's no super-clear
-  // advantage to this yet. The main reason might be if we decide to delete some
-  // backward-compatibility code which knows how to deal with an older release,
-  // but if we actually do that, we can change this code to add the extra
-  // springboard at that time.
-  var upgraders = require('../upgraders.js');
-  var upgradersToRun = upgraders.upgradersToRun(projectContext);
-
-  // Update every package in .meteor/packages to be (semver)>= the version
-  // set for that package in the release we are updating to
   var releaseRecord = catalog.official.getReleaseVersion(releaseTrack, releaseVersion);
-  projectContext.projectConstraintsFile.updateReleaseConstraints(releaseRecord);
-
-  // Download and build packages and write the new versions to .meteor/versions.
-  // XXX It's a little weird that we do a full preparation for build
-  //     (downloading packages, building packages, etc) when we might be about
-  //     to upgrade packages and have to do it again. Maybe we shouldn't? Note
-  //     that if we change this, that changes the upgraders interface, which
-  //     expects a projectContext that is fully prepared for build.
-  main.captureAndExit("=> Errors while initializing project:", function () {
-    projectContext.prepareProjectForBuild();
-  });
-
-  projectContext.writeReleaseFileAndDevBundleLink(releaseName);
-
-  projectContext.packageMapDelta.displayOnConsole({
-    title: ("Changes to your project's package version selections from " +
-            "updating the release:")
-  });
-
-  Console.info(files.pathBasename(options.appDir) + ": updated to " +
-               projectContext.releaseFile.displayReleaseName + ".");
-
-  // Now run the upgraders.
-  // XXX should we also run upgraders on other random commands, in case there
-  // was a crash after changing .meteor/release but before running them?
-  _.each(upgradersToRun, function (upgrader) {
-    upgraders.runUpgrader(projectContext, upgrader);
-    projectContext.finishedUpgraders.appendUpgraders([upgrader]);
-  });
+  doUpdateRelease(options, projectContext, releaseName, releaseRecord);
 
   // We are done, and we should pass the release that we upgraded to, to the
   // user.

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -859,7 +859,7 @@ main.registerCommand({
     // If we are on a checkout, we don't need to do this as running from
     // checkout still pins all package versions and if the user updates
     // to a real release, the packages file will subsequently get updated
-    if (!release.current.isCheckout()) {
+    if (!release.current.isCheckout() || process.env.METEOR_CHECKOUT_IS_RELEASE) {
       projectContext.projectConstraintsFile
         .updateReleaseConstraints(release.current._manifest);
     }

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -2004,6 +2004,8 @@ function doTestCommand(options) {
       // may or may not exist yet
       const appDirPath = files.pathJoin(options.appDir, ...parts);
       const testDirPath = files.pathJoin(testRunnerAppDir, ...parts);
+      if (appDirPath == testDirPath)
+         return;
 
       files.mkdir_p(appDirPath);
       files.mkdir_p(files.pathDirname(testDirPath));

--- a/tools/isobuild/builder.js
+++ b/tools/isobuild/builder.js
@@ -625,7 +625,7 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
       }
     }
 
-    ignore = ignore || [];
+    ignore = ignore || [/\.git\//];
     let specificPaths = null;
     if (specificFiles) {
       specificPaths = {};

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -2073,6 +2073,38 @@ class JsImage {
       }
     };
 
+	var getAssetAsync = function (assets, assetPath, encoding, callback) {
+	  assetPath = files.convertToStandardPath(assetPath);
+	  var promise;
+	  if (! callback) {
+		  promise = new Promise(function (resolve, reject) {
+			  callback = function (err, res) {
+				  err ? reject(err) : resolve(res);
+			  };
+		  });
+	  }
+
+	  var _callback = function (err, result) {
+		  if (result && ! encoding) {
+			  // Sadly, this copies in Node 0.10.
+			  result = new Uint8Array(result);
+		  }
+		  callback(err, result);
+	  };
+
+	  if (!assets || !_.has(assets, assetPath)) {
+		  _callback(new Error("Unknown asset: " + assetPath));
+	  } else {
+		  var buffer = assets[assetPath];
+		  var result = encoding ? buffer.toString(encoding) : buffer;
+		  _callback(null, result);
+	  }
+
+	  if (promise) {
+		  return promise;
+	  }
+	};
+
     const nodeModulesDirsByPackageName = new Map;
 
     _.each(self.jsToLoad, item => {
@@ -2229,6 +2261,10 @@ class JsImage {
             return getAsset(item.assets, assetPath, "utf8", callback);
           },
 
+		  getTextAsync: function (assetPath) {
+			return getAssetAsync(item.assets, assetPath, "utf8");
+		  },
+
           /**
            * @summary Retrieve the contents of the static server asset as an [EJSON Binary](#ejson_new_binary).
            * @locus Server
@@ -2238,7 +2274,11 @@ class JsImage {
            */
           getBinary: function (assetPath, callback) {
             return getAsset(item.assets, assetPath, undefined, callback);
-          }
+          },
+
+		  getBinaryAsync: function (assetPath) {
+			return getAssetAsync(item.assets, assetPath, undefined);
+		  }
         }
       }, bindings || {});
 

--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -601,6 +601,8 @@ class ResourceSlot {
   // original data. #HardcodeJs
   _addDirectlyToJsOutputResources() {
     this.addJavaScript({
+      bare: this.inputResource.bare,
+      sourceMap: this.inputResource.sourceMap,
       ...(this.inputResource.fileOptions || {}),
       path: this.inputResource.path,
       data: this.inputResource.data,

--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -125,6 +125,15 @@ Object.assign(Module.prototype, {
       const eagerFiles = _.filter(self.files, file => ! file.lazy);
 
       return _.map(eagerFiles, function (file) {
+        if (file.bare) {
+          return {
+            source: file.source,
+            sourcePath: file.sourcePath,
+            servePath: file.servePath,
+            sourceMap: file.sourceMap,
+          };
+        }
+
         const cacheKey = JSON.stringify([
           file._inputHash,
           file.bare,

--- a/tools/meteor-services/deploy.js
+++ b/tools/meteor-services/deploy.js
@@ -480,7 +480,7 @@ async function pollForDeploy(pollingState, versionId, site, deployWithTokenProps
 //   for deploy status
 export async function bundleAndDeploy(options) {
   if (options.recordPackageUsage === undefined) {
-    options.recordPackageUsage = true;
+    options.recordPackageUsage = false;
   }
 
   // we don't need site for build-only

--- a/tools/meteor-services/service-connection.js
+++ b/tools/meteor-services/service-connection.js
@@ -32,7 +32,7 @@ var ServiceConnection = function (endpointUrl, options) {
     // We found that this was likely to time out with the DDP default of 10s,
     // especially if the CPU is churning on bundling (eg, for the stats
     // connection which we start in parallel with bundling).
-    connectTimeoutMs: 30000,
+    connectTimeoutMs: 900000,
     // Disable client->server heartbeats for service connections.  Users with
     // slow internet connections were seeing heartbeat timeouts because the
     // heartbeats were buried behind large responses (eg

--- a/tools/packaging/catalog/catalog-local.js
+++ b/tools/packaging/catalog/catalog-local.js
@@ -181,6 +181,32 @@ Object.assign(LocalCatalog.prototype, {
       throw new Error("catalog not initialized yet?");
   },
 
+  // Return an object suitable as a release record
+  getReleaseRecord: function () {
+    var self = this;
+    self._requireInitialized();
+    var record = {
+      track: 'METEOR',
+      version: 'checkout',
+      orderKey: 'zzz',
+      description: 'The release represented by the current checkout',
+      recommended: true,
+      tool: 'meteor-tool@???',
+      packages: {},
+      publishedBy: { username: 'local', id: 'local' },
+      lastUpdated: new Date().toString(),
+      published: new Date().toString()
+    };
+
+    for (let [packageName, package] of Object.entries(self.packages)) {
+      if (package.versionRecord.isTest)
+        continue;
+      record.packages[packageName] = package.versionRecord.version;
+    }
+
+    return record;
+  },
+
   // Return an array with the names of all of the packages that we know about,
   // in no particular order.
   getAllPackageNames: function (options) {

--- a/tools/runners/run-app.js
+++ b/tools/runners/run-app.js
@@ -369,7 +369,7 @@ var AppRunner = function (options) {
   self.onRunEnd = options.onRunEnd;
   self.noRestartBanner = options.noRestartBanner;
   self.recordPackageUsage =
-    options.recordPackageUsage === undefined ? true : options.recordPackageUsage;
+    options.recordPackageUsage === undefined ? false : options.recordPackageUsage;
   self.omitPackageMapDeltaDisplayOnFirstRun =
     options.omitPackageMapDeltaDisplayOnFirstRun;
 

--- a/tools/tool-env/isopackets.js
+++ b/tools/tool-env/isopackets.js
@@ -231,7 +231,7 @@ export function ensureIsopacketsLoadable() {
 }
 
 // Returns a new all-local-packages catalog to be used for building isopackets.
-var newIsopacketBuildingCatalog = function () {
+export function newIsopacketBuildingCatalog() {
   if (!files.inCheckout()) {
     throw Error("No need to build isopackets unless in checkout!");
   }

--- a/tools/utils/archinfo.ts
+++ b/tools/utils/archinfo.ts
@@ -131,6 +131,7 @@ export const VALID_ARCHITECTURES: Record<string, boolean> = {
   "os.osx.x86_64": true,
   "os.osx.arm64": true,
   "os.linux.x86_64": true,
+  "os.linux.aarch64": true,
   "os.windows.x86_64": true,
 };
 
@@ -171,7 +172,9 @@ export function host() {
       }
     } else if (platform === "linux") {
       const machine = run('uname', '-m');
-      if (["x86_64", "amd64", "ia64"].includes(machine)) {
+      if (["aarch64"].includes(machine)) {
+        _host = "os.linux.aarch64";
+      } else if (["x86_64", "amd64", "ia64"].includes(machine)) {
         _host = "os.linux.x86_64";
       } else {
         throw new Error(`Unsupported architecture: ${machine}`);

--- a/tools/utils/utils.js
+++ b/tools/utils/utils.js
@@ -697,6 +697,7 @@ export function architecture() {
     Linux: {
       ia32: 'i686',
       x64: 'x86_64',
+      aarch64: 'aarch64',
     },
     Windows_NT: {
       ia32: process.env.hasOwnProperty('PROCESSOR_ARCHITEW6432')


### PR DESCRIPTION
We had to do a couple of changes on the meteor side, more specifically adding the `async` API for `Assets` and ensuring the loop actions from cursors correctly wait `async` methods.

The approach with the `wrapFn` was selected because it reduces noise through the code, so we don't need to find where each callback is called and wrap it with a `Promise.await`, instead we can just change the definition to wait automatically for us when needed and not break simulations/client/shared code.